### PR TITLE
Fix/pending jobs invisible if q specified

### DIFF
--- a/cmd/gridengine_exporter/main.go
+++ b/cmd/gridengine_exporter/main.go
@@ -11,13 +11,11 @@ import (
 )
 
 var addr = flag.String("listen-address", ":8080", "The address to listen on for HTTP requests.")
-var filter = flag.String("host-filter", "*", "Host to filter for, if not wildcard, only metrics for specified host is collected.")
 
 func main() {
 	flag.Parse()
 
 	gridengineCollector := collector.NewGridengineCollector()
-	gridengineCollector.Filter = *filter
 	prometheus.MustRegister(gridengineCollector)
 
 	http.Handle("/metrics", promhttp.Handler())

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -59,7 +59,7 @@ func (collector *GridengineCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (collector *GridengineCollector) Collect(ch chan<- prometheus.Metric) {
-	hosts, pendingJobs, err := gridengine.GetHostQueuesJobs(collector.Filter)
+	hosts, pendingJobs, err := gridengine.GetHostQueuesJobs()
 	if err != nil {
 		log.Printf("failed to get gridengine data: %v", err)
 		return

--- a/pkg/gridengine/main.go
+++ b/pkg/gridengine/main.go
@@ -166,15 +166,8 @@ func processJobs(qjobs []xmltypes.Job) []Job {
 	return jobs
 }
 
-func GetHostQueuesJobs(filter string) (map[string]Host, []Job, error) {
-	if len(filter) == 0 {
-		filter = "*"
-	}
-
+func GetHostQueuesJobs() (map[string]Host, []Job, error) {
 	qhostCmd := exec.Command("qhost", "-q", "-xml")
-	if filter != "*" {
-		qhostCmd.Args = append(qhostCmd.Args, "-h", filter)
-	}
 	qhostRawXml, err := qhostCmd.Output()
 	if err != nil {
 		return nil, nil, fmt.Errorf("qhost returned non zero: %v", err)
@@ -186,7 +179,7 @@ func GetHostQueuesJobs(filter string) (map[string]Host, []Job, error) {
 		return nil, nil, fmt.Errorf("error parsing qhost xml: %v", err)
 	}
 
-	qstatRawXml, err := exec.Command("qstat", "-u", "*", "-q", "*@"+filter, "-xml", "-f").Output()
+	qstatRawXml, err := exec.Command("qstat", "-u", "*", "-xml", "-f").Output()
 	if err != nil {
 		return nil, nil, fmt.Errorf("qstat returned non zero: %v", err)
 	}

--- a/pkg/xml/types.go
+++ b/pkg/xml/types.go
@@ -9,6 +9,7 @@ type Job struct {
 	Owner        string   `xml:"JB_owner"`
 	State        string   `xml:"state"`
 	Slots        int      `xml:"slots"`
+	Tasks        string   `xml:"tasks,omitempty"`
 	Priority     float32  `xml:"JAT_prio"`
 	StartTimeStr string   `xml:"JAT_start_time"`
 }


### PR DESCRIPTION
When using load_values as a requestable parameter in job (e.g. -l mem_free=2G). It will not be shown in case the -q param is specified in qstat.

This is due to the way how load_values are used. Scheduler will assign the queue at the moment of start of the job, as there is no way for scheduler to know, how the load_value will behave in the future. (kinda like Schroedinger job...)
